### PR TITLE
Waterlevel property

### DIFF
--- a/OpenChannelJunction/examples/example-normalized.json
+++ b/OpenChannelJunction/examples/example-normalized.json
@@ -109,6 +109,6 @@
     "value": 0.56
   },
   "@context": [
-    "https://smartdatamodels.org/context.jsonld"
+    "https://raw.githubusercontent.com/smart-data-models/dataModel.OpenChannelManagement/master/context.jsonld"
   ]
 }

--- a/OpenChannelJunction/examples/example-normalized.json
+++ b/OpenChannelJunction/examples/example-normalized.json
@@ -107,8 +107,5 @@
   "waterLevel": {
     "type": "Number",
     "value": 0.56
-  },
-  "@context": [
-    "https://raw.githubusercontent.com/smart-data-models/dataModel.OpenChannelManagement/master/context.jsonld"
-  ]
+  }
 }

--- a/OpenChannelJunction/examples/example-normalized.json
+++ b/OpenChannelJunction/examples/example-normalized.json
@@ -104,6 +104,10 @@
     "type": "Number",
     "value": 0.15
   },
+  "waterLevel": {
+    "type": "Number",
+    "value": 0.56
+  },
   "@context": [
     "https://smartdatamodels.org/context.jsonld"
   ]

--- a/OpenChannelJunction/examples/example-normalized.jsonld
+++ b/OpenChannelJunction/examples/example-normalized.jsonld
@@ -110,6 +110,10 @@
         "type": "Property",
         "value": 0.12
     },
+    "waterLevel": {
+        "type": "Property",
+        "value": 0.56
+    },
     "@context": [
         "https://raw.githubusercontent.com/smart-data-models/dataModel.OpenChannelManagement/master/context.jsonld"
     ]

--- a/OpenChannelJunction/examples/example.json
+++ b/OpenChannelJunction/examples/example.json
@@ -41,5 +41,6 @@
   "uniqueName": "J1",
   "tag": "",
   "waterOutflow": 0.12,
-  "waterInflow": 0.15
+  "waterInflow": 0.15,
+  "waterLevel": 0.85
 }

--- a/OpenChannelJunction/examples/example.json
+++ b/OpenChannelJunction/examples/example.json
@@ -33,13 +33,13 @@
   ],
   "position": {
     "distance": 160.6,
-    "refPoint": "urn:ngsi-ld:OpenChannelJunction:refPoint:JXFD:60487647",
-    "downstreamNode": "urn:ngsi-ld:OpenChannelJunction:downstreamNode:CBWI:21948924",
-    "upstreamNode": "urn:ngsi-ld:OpenChannelJunction:upstreamNode:MWGU:81565938",
-    "observedBy": "urn:ngsi-ld:OpenChannelJunction:observedBy:GIWE:80160975",
-    "uniqueName": "J1",
-    "tag": "",
-    "waterOutflow": 0.12,
-    "waterInflow": 0.15
-  }
+    "refPoint": "urn:ngsi-ld:OpenChannelJunction:refPoint:JXFD:60487647"
+  },
+  "downstreamNode": "urn:ngsi-ld:OpenChannelJunction:downstreamNode:CBWI:21948924",
+  "upstreamNode": "urn:ngsi-ld:OpenChannelJunction:upstreamNode:MWGU:81565938",
+  "observedBy": "urn:ngsi-ld:OpenChannelJunction:observedBy:GIWE:80160975",
+  "uniqueName": "J1",
+  "tag": "",
+  "waterOutflow": 0.12,
+  "waterInflow": 0.15
 }

--- a/OpenChannelJunction/examples/example.jsonld
+++ b/OpenChannelJunction/examples/example.jsonld
@@ -28,15 +28,15 @@
     ],
     "position": {
         "distance": 160.6,
-        "refPoint": "urn:ngsi-ld:OpenChannelJunction:refPoint:JXFD:60487647",
-        "downstreamNode": "urn:ngsi-ld:OpenChannelJunction:downstreamNode:CBWI:21948924",
-        "upstreamNode": "urn:ngsi-ld:OpenChannelJunction:upstreamNode:MWGU:81565938",
-        "observedBy": "urn:ngsi-ld:OpenChannelJunction:observedBy:GIWE:80160975",
-        "uniqueName": "J1",
-        "tag": "",
-        "waterOutflow": 0.12,
-        "waterInflow": 0.15
+        "refPoint": "urn:ngsi-ld:OpenChannelJunction:refPoint:JXFD:60487647"
     },
+    "downstreamNode": "urn:ngsi-ld:OpenChannelJunction:downstreamNode:CBWI:21948924",
+    "upstreamNode": "urn:ngsi-ld:OpenChannelJunction:upstreamNode:MWGU:81565938",
+    "observedBy": "urn:ngsi-ld:OpenChannelJunction:observedBy:GIWE:80160975",
+    "uniqueName": "J1",
+    "tag": "",
+    "waterOutflow": 0.12,
+    "waterInflow": 0.15,
     "seeAlso": [
         "urn:ngsi-ld:OpenChannelJunction:items:KTWJ:61564622",
         "urn:ngsi-ld:OpenChannelJunction:items:JOMY:24566116"

--- a/OpenChannelJunction/examples/example.jsonld
+++ b/OpenChannelJunction/examples/example.jsonld
@@ -37,6 +37,7 @@
     "tag": "",
     "waterOutflow": 0.12,
     "waterInflow": 0.15,
+    "waterLevel": 0.85,
     "seeAlso": [
         "urn:ngsi-ld:OpenChannelJunction:items:KTWJ:61564622",
         "urn:ngsi-ld:OpenChannelJunction:items:JOMY:24566116"

--- a/OpenChannelJunction/schema.json
+++ b/OpenChannelJunction/schema.json
@@ -116,6 +116,11 @@
           "type": "number",
           "minimum": 0,
           "description": "Property. Water flow inserted to the junction. Units:'m3/s'"
+        },
+        "waterLevel": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Property. Water level at the junction. Units:'m'"
         }
       }
     }


### PR DESCRIPTION
See https://github.com/smart-data-models/dataModel.OpenChannelManagement/issues/3 for the discussion. This PR adds a `waterLevel` property at the junction level.

When adjusting the `example.json` and `example.jsonld` I noted the _position_ property included also some other top-level properties in the examples, so I [adjusted this first](cb7b494f29d00a6990a36c38d8f346b996b708f7). 

